### PR TITLE
Pushed hierarchical `nav` into `.header` scope

### DIFF
--- a/source/stylesheets/_header.sass
+++ b/source/stylesheets/_header.sass
@@ -23,36 +23,36 @@
         color: $red-bright
         transition: $all
 
-nav
-  a
-    display: block
-    padding: 1.3em
-    &:hover
-      background: $header-link-hover
-  ul
-    padding: 0
-    margin: 0
-    li
-      background: $header
-      display: inline
-      float: left
-      position: relative
-      ul
-        left: 0
-        top: 100%
+  nav
+    a
+      display: block
+      padding: 1.3em
+      &:hover
+        background: $header-link-hover
     ul
-      display: none
-  li:hover > ul
-    display: block
-    position: absolute
-    width: 12.5em
-    z-index: 9000
-    li
-      width: 100%
-  ul ul li:hover > ul
-    left: auto
-    right: -12.5em
-    top: 0
+      padding: 0
+      margin: 0
+      li
+        background: $header
+        display: inline
+        float: left
+        position: relative
+        ul
+          left: 0
+          top: 100%
+      ul
+        display: none
+    li:hover > ul
+      display: block
+      position: absolute
+      width: 12.5em
+      z-index: 9000
+      li
+        width: 100%
+    ul ul li:hover > ul
+      left: auto
+      right: -12.5em
+      top: 0
 
 #menu-toggle, #menu-toggle-label
   cursor: pointer


### PR DESCRIPTION
This could resolve #3. The proposed change *will break* nav styling for people relying on the use without `.header` scoping.