### PR TITLE
Bower and NPM support

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,15 @@
+**/.*
+*.gemspec
+Gemfile*
+Rakefile
+node_modules
+bower_components
+test
+tests
+build
+pkg
+previews
+docs
+icons
+lib
+releases

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    vital (1.2.0)
+    vital (1.2.1)
       sass (>= 3.4)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A minimally invasive CSS framework for modern web applications.
 A couple installation options are available:
 
 - Download the latest release tarball from https://github.com/doximity/vital/releases.
-- Install the `vital` Ruby Gem on your project.
+- Install the `vital` RubyGem or Bower package on your project.
 - Use a precompiled release from RawGit.
 
 Check out [our docs](http://vitalcss.com/get-started/) for information on installation methods, framework contents, templates, examples and more.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ bundle exec middleman
 - `git commit -m 'vX.Y.Z'`
 - `git push origin master`
 - `bundle exec rake release` to push to RubyGems
+- `npm publish` to push to NPM
 - `cd docs && bundle exec rake publish` to update GitHub pages
 - Go to https://github.com/doximity/vital/releases and create a new release with the tarball attached
 - Visit http://vitalcss.com/ and ensure it has been updated

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A minimally invasive CSS framework for modern web applications.
 A couple installation options are available:
 
 - Download the latest release tarball from https://github.com/doximity/vital/releases.
-- Install the `vital` RubyGem or Bower package on your project.
+- Install the `vital` RubyGem, NPM or Bower package on your project.
 - Use a precompiled release from RawGit.
 
 Check out [our docs](http://vitalcss.com/get-started/) for information on installation methods, framework contents, templates, examples and more.

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,27 @@
+{
+  "name": "vital",
+  "homepage": "http://vitalcss.com",
+  "authors": [
+    "Body Taing <btaing@doximity.com>",
+    "Fabio Rehm <frehm@doximity.com>"
+  ],
+  "description": "A minimally invasive CSS framework for modern web applications.",
+  "main": [
+    "sass/vital.sass"
+  ],
+  "license": "Apache-2.0",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests",
+    "build",
+    "pkg",
+    "previews",
+    "docs",
+    "icons",
+    "lib",
+    "releases"
+  ]
+}

--- a/bower.json
+++ b/bower.json
@@ -12,6 +12,9 @@
   "license": "Apache-2.0",
   "ignore": [
     "**/.*",
+    "*.gemspec",
+    "Gemfile*",
+    "Rakefile",
     "node_modules",
     "bower_components",
     "test",

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    vital (1.2.0)
+    vital (1.2.1)
       sass (>= 3.4)
 
 GEM

--- a/docs/get-started.html.slim
+++ b/docs/get-started.html.slim
@@ -67,11 +67,14 @@
         @import vital/all
 
     hr
-    h2 Bower
+    h2 Bower / NPM
     = code('sh') do
       |
         bower install --save vital
+        npm install --save vital
     p
       ' And reference the assets from within your project's
       code bower_components/vital
+      | or
+      code node_modules/vital
       | directory

--- a/docs/get-started.html.slim
+++ b/docs/get-started.html.slim
@@ -67,5 +67,11 @@
         @import vital/all
 
     hr
-    h2 NPM
-    p A NPM package is in the works.
+    h2 Bower
+    = code('sh') do
+      |
+        bower install --save vital
+    p
+      ' And reference the assets from within your project's
+      code bower_components/vital
+      | directory

--- a/docs/get-started.html.slim
+++ b/docs/get-started.html.slim
@@ -11,7 +11,7 @@
     h2 Quickest (Compiled)
     p Import into stylesheet or as a stylesheet link tag:
     p
-      code https://cdn.rawgit.com/doximity/vital/v1.2.0/dist/css/vital.min.css
+      code https://cdn.rawgit.com/doximity/vital/v1.2.1/dist/css/vital.min.css
     hr
     h2 Recommended (Source)
     p

--- a/docs/get-started.html.slim
+++ b/docs/get-started.html.slim
@@ -71,10 +71,10 @@
     = code('sh') do
       |
         bower install --save vital
-        npm install --save vital
+        npm install --save vital-css
     p
       ' And reference the assets from within your project's
       code bower_components/vital
       | or
-      code node_modules/vital
+      code node_modules/vital-css
       | directory

--- a/lib/vital/version.rb
+++ b/lib/vital/version.rb
@@ -1,3 +1,3 @@
 module Vital
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vital",
+  "name": "vital-css",
   "version": "1.2.1",
   "description": "A minimally invasive CSS framework for modern web applications.",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "vital",
+  "version": "1.2.0",
+  "description": "A minimally invasive CSS framework for modern web applications.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/doximity/vital.git"
+  },
+  "author": "The Vital Authors (https://github.com/doximity/vital/graphs/contributors)",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/doximity/vital/issues"
+  },
+  "homepage": "https://github.com/doximity/vital#readme"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vital",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A minimally invasive CSS framework for modern web applications.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes GH-16
Replaces GH-31
---

You can try this today using `bower install doximity/vital#bower-and-npm-support` / `npm install doximity/vital#bower-and-npm-support` and you'll get something like the following under your `bower_components` / `node_modules`:

```
vital
    ├── CHANGELOG.md
    ├── CONTRIBUTING.md
    ├── LICENSE.md
    ├── README.md
    ├── bower.json
    ├── dist
    │   ├── css
    │   │   ├── vital.css
    │   │   ├── vital.css.map
    │   │   ├── vital.min.css
    │   │   └── vital.min.css.map
    │   └── fonts
    │       ├── icons.eot
    │       ├── icons.svg
    │       ├── icons.ttf
    │       └── icons.woff
    ├── fontcustom.yml
    ├── fonts
    │   ├── icons.eot
    │   ├── icons.svg
    │   ├── icons.ttf
    │   └── icons.woff
    └── sass
        ├── vital
        │   ├── _all.sass
        │   ├── _base.sass
        │   ├── _buttons.sass
        │   ├── _custom.sass
        │   ├── _footer.sass
        │   ├── _forms.sass
        │   ├── _grid.sass
        │   ├── _header.sass
        │   ├── _helpers.sass
        │   ├── _heroes.sass
        │   ├── _icons.sass
        │   ├── _loaders.sass
        │   ├── _normalize.sass
        │   ├── _notice.sass
        │   ├── _pagination.sass
        │   ├── _sprockets.sass
        │   ├── _syntax.sass
        │   ├── _tables.sass
        │   ├── _tabs.sass
        │   └── _variables.sass
        ├── vital.css.sass
        └── vital.sass
```

People are free to reference `sass` files or the precompiled `css` directly. I'm not too familiar with bower / NPM to know if there is anything else we gotta do before cutting our very first release so any feedback would be greatly appreciated.
