### PR TITLE
Deploy VitalCSS docs website to S3 using GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy VitalCSS docs website to S3
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "docs/**"
+
+jobs:
+  docs_deploy_s3:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    defaults:
+      run:
+        working-directory: docs
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.4.2
+          working-directory: docs
+          bundler-cache: true
+
+      - name: Middleman build
+        run: make build
+
+      - name: Setup AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.VITALCSS_AWS_DEPLOY_ROLE }}
+
+      - name: Publish docs website to S3
+        env:
+          VITALCSS_DIST_ID: ${{ secrets.VITALCSS_DIST_ID }}
+        run: make publish

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,8 +6,11 @@
 set_index:
 	aws s3 website s3://dox-vitalcss --index-document index.html
 
+build:
+	bundle exec middleman build
+
 publish:
 	aws configure set preview.cloudfront true
 	aws configure set preview.create-invalidation true
 	aws s3 sync --acl public-read --delete build/ s3://vitalcss
-	aws cloudfront create-invalidation --distribution-id ${VITALCSS_DIST_ID} --paths /*
+	aws cloudfront create-invalidation --distribution-id ${VITALCSS_DIST_ID} --paths "/*"

--- a/docs/config.rb
+++ b/docs/config.rb
@@ -62,11 +62,10 @@ end
 
 # Build-specific configuration
 configure :build do
-
   activate :robots, :rules => [
     {:user_agent => '*', :allow => %w(/)}
   ],
-  sitemap: '#{data.site.url}/sitemap.xml'
+  sitemap: "#{@app.data.site.url}/sitemap.xml"
 
   # Minify on build
   activate :minify_html

--- a/docs/config.rb
+++ b/docs/config.rb
@@ -23,6 +23,14 @@ import_path "#{Vital.gem_path}/fonts"
 
 # General configuration
 
+# Ignore files on build
+ignore "/.gitignore"
+ignore "/config.rb"
+ignore "/config.ru"
+ignore "/Gemfile*"
+ignore "/Makefile"
+ignore "/Rakefile"
+
 # Syntax highlighting
 activate :syntax
 # Pretty URLs


### PR DESCRIPTION
[ST-630](https://doximity.atlassian.net/browse/ST-630)

## Description

Add a new GitHub Action workflow to build and deploy the documentation website to S3 on every push to master.

Example action run: https://github.com/doximity/vital/actions/runs/4801387339/jobs/8543521117

We also did a few improvements/fixes:

* Ignore some files on  build b2087bdd644ffc082e468a88a31aab90b9a56831
* Fix robots.txt file generation 50e55deccb7c4bc126a003957e0ff3944abf63ce

[ST-630]: https://doximity.atlassian.net/browse/ST-630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ