### PR TITLE
Update to self hosted GHA runner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   docs_deploy_s3:
-    runs-on: ubuntu-latest
+    runs-on: general-purpose
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Updating from the GHA cloud runner instance to our own self hosted runners, the cost of cloud runners is ~4x what we spend to self host.

[_Created by Sourcegraph batch change `NoHesHere/update-to-general-purpose`._](https://sourcegraph.build.dox.pub/users/NoHesHere/batch-changes/update-to-general-purpose)